### PR TITLE
Feature/issues 21 icon button

### DIFF
--- a/src/components/common/atoms/IconButton.stories.tsx
+++ b/src/components/common/atoms/IconButton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import IconButton from './IconButton';
+import { IconButton } from './IconButton';
 import { MoreHoriz } from '@mui/icons-material';
 
 const meta: Meta<typeof IconButton> = {

--- a/src/components/common/atoms/IconButton.stories.tsx
+++ b/src/components/common/atoms/IconButton.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import IconButton from './IconButton';
+import { MoreHoriz } from '@mui/icons-material';
+
+const meta: Meta<typeof IconButton> = {
+  component: IconButton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// childrenにReactElement渡したい場合はファイル形式をtsxにするしかない？
+// UIのドロップダウンからアイコン切り替えできると便利だよね…
+export const DefaultIconButton: Story = {
+  args: {
+    children: <MoreHoriz />,
+    color: 'primary',
+    variant: 'icon',
+  },
+};

--- a/src/components/common/atoms/IconButton.tsx
+++ b/src/components/common/atoms/IconButton.tsx
@@ -1,29 +1,48 @@
 'use client';
 
-import { styled, IconButton as MuiDefaultIconButton } from '@mui/material';
-import type { IconButtonProps, ButtonProps } from '@mui/material';
+// FIXME 関連Issues → https://github.com/cuculus-dev/cuculus/issues/21
 
-interface ExtraProps extends IconButtonProps {
+import { styled, IconButton as MuiDefaultIconButton } from '@mui/material';
+import type {
+  IconButtonProps as MuiDefaultIconButtonProps,
+  ButtonProps,
+} from '@mui/material';
+
+interface IconButtonProps extends MuiDefaultIconButtonProps {
   variant?: Exclude<NonNullable<ButtonProps['variant']>, 'text'> | 'icon';
 }
 
 const IconButton = styled(MuiDefaultIconButton, {
   shouldForwardProp: (prop) => prop !== 'variant',
-})<ExtraProps>(({ variant, color }) => {
+})<IconButtonProps>(({ variant, color }) => {
+  // FIXME ButtonとIconButtonで高さが異なる問題。ベタ書きで暫定対処。
+  const width = 36;
+  const height = width;
+
   switch (variant) {
     case 'outlined':
       return {
-        outlineWidth: 1,
+        // FIXME 透明度が効いてない
+        color,
+        height,
         outlineStyle: 'solid',
+        outlineWidth: 1,
+        width,
       };
     case 'contained':
-      // FIXME 色効かない
       return {
+        // FIXME 色がつかない
         backgroundColor: color,
+        height,
+        width,
       };
     case 'icon':
-      return {};
+      return {
+        height,
+        width,
+      };
   }
 });
 
-export default IconButton;
+export type { IconButtonProps };
+export { IconButton };

--- a/src/components/common/atoms/IconButton.tsx
+++ b/src/components/common/atoms/IconButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { styled, IconButton as MuiDefaultIconButton } from '@mui/material';
+import type { IconButtonProps, ButtonProps } from '@mui/material';
+
+interface ExtraProps extends IconButtonProps {
+  variant?: Exclude<NonNullable<ButtonProps['variant']>, 'text'> | 'icon';
+}
+
+const IconButton = styled(MuiDefaultIconButton, {
+  shouldForwardProp: (prop) => prop !== 'variant',
+})<ExtraProps>(({ variant, color }) => {
+  switch (variant) {
+    case 'outlined':
+      return {
+        outlineWidth: 1,
+        outlineStyle: 'solid',
+      };
+    case 'contained':
+      // FIXME 色効かない
+      return {
+        backgroundColor: color,
+      };
+    case 'icon':
+      return {};
+  }
+});
+
+export default IconButton;


### PR DESCRIPTION
## Ticket

- Github Issue: cuculus-dev/cuculus/issues/21

## 変更内容
`variant`プロパティを追加したカスタムIconButtonコンポーネントを追加。

## 確認方法
`npm run storybook`

## Screenshot (任意)
![image](https://github.com/cuculus-dev/cuculus/assets/141975947/8a40f634-00a6-4411-aef2-d0160a578f50)

## 既知の不具合
- `color`の透明度が効いていない
- `variant="contained"`の場合に色がつかない
- 高さ・幅がベタ書き
  - Buttonの高さは36.5pxだが、同じ高さに設定すると1pxはみ出るっぽいので36pxで指定。 \
  ![image](https://github.com/cuculus-dev/cuculus/assets/141975947/a4621613-652c-4f54-a0c8-e0788a173f23) ← 36.5px | 36px → ![image](https://github.com/cuculus-dev/cuculus/assets/141975947/ecdd97b3-f046-4507-8cf6-a1aa0d36e988)

