### PR TITLE
モバイル用の下部メニューを作成

### DIFF
--- a/src/app/(menu)/layout.tsx
+++ b/src/app/(menu)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { styled } from '@mui/material';
 import SideMenu from '@/features/menu/SideMenu';
+import MobileBottomMenu from '@/features/mobile-menu/MobileBottomMenu';
 import { ReactNode } from 'react';
 
 const Layout = styled('div')`
@@ -36,6 +37,7 @@ export default function MenuLayout({ children }: { children: ReactNode }) {
       <SideMenu />
       {children}
       <div />
+      <MobileBottomMenu />
     </Layout>
   );
 }

--- a/src/features/mobile-menu/MobileBottomMenu.tsx
+++ b/src/features/mobile-menu/MobileBottomMenu.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import MobileBottomMenuLinkItem from '@/features/mobile-menu/elements/MobileBottomMenuLinkItem';
+import { useProfile } from '@/swr/client/auth';
+import { Home, Mail, Notifications, Search } from '@mui/icons-material';
+import { styled } from '@mui/material';
+
+const Menu = styled('nav')`
+  ${({ theme }) => theme.breakpoints.up('tablet')} {
+    display: none;
+  }
+
+  background-color: white;
+  border-top: solid 1px lightgray;
+
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+`;
+
+export default function MobileBottomMenu() {
+  const { data: profile } = useProfile();
+
+  return (
+    <>
+      {profile && (
+        <Menu>
+          <MobileBottomMenuLinkItem icon={<Home />} href={'/home'} />
+          <MobileBottomMenuLinkItem icon={<Search />} href={'/search'} />
+          <MobileBottomMenuLinkItem
+            icon={<Notifications />}
+            href={'/notifications'}
+          />
+          <MobileBottomMenuLinkItem icon={<Mail />} href={'/messages'} />
+        </Menu>
+      )}
+    </>
+  );
+}

--- a/src/features/mobile-menu/elements/MobileBottomMenuItemStyleBase.tsx
+++ b/src/features/mobile-menu/elements/MobileBottomMenuItemStyleBase.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { Box, styled } from '@mui/material';
+
+const MobileBottomMenuItemStyleBase = styled(Box)`
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 1px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  & svg {
+    font-size: 4rem;
+  }
+`;
+
+export default MobileBottomMenuItemStyleBase;

--- a/src/features/mobile-menu/elements/MobileBottomMenuLinkItem.tsx
+++ b/src/features/mobile-menu/elements/MobileBottomMenuLinkItem.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import MobileBottomMenuItemStyleBase from '@/features/mobile-menu/elements/MobileBottomMenuItemStyleBase';
+import { styled } from '@mui/material';
+import NextLink from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ReactNode } from 'react';
+
+const StyledLink = styled(NextLink)`
+  align-items: center;
+  color: black;
+  text-decoration: none;
+
+  display: flex;
+  flex-direction: column;
+
+  &::after {
+    font-size: 1.5rem;
+    line-height: 1rem;
+  }
+
+  &.active::after {
+    content: '・';
+  }
+
+  &:not(.active)::after {
+    content: '　';
+  }
+`;
+
+interface Props {
+  href: string;
+  icon: ReactNode;
+}
+
+const MobileBottomMenuLinkItem = ({ href, icon }: Props) => {
+  const pathname = usePathname();
+
+  return (
+    <MobileBottomMenuItemStyleBase>
+      <StyledLink
+        href={href}
+        className={href === pathname ? 'active' : undefined}
+      >
+        {icon}
+      </StyledLink>
+    </MobileBottomMenuItemStyleBase>
+  );
+};
+
+export default MobileBottomMenuLinkItem;


### PR DESCRIPTION
## Issue

- Github Issue: #59 

## 変更内容
モバイル用の下部メニューを追加

## 確認方法
ログイン状態で任意のページを表示してください。

## Screenshot (任意)
[ScreenRecord](https://github.com/cuculus-dev/cuculus/assets/141975947/5b0fa2f8-b7cf-499f-86ea-e8db8446495e)
