### PR TITLE
古いプロフィール情報などが表示されてしまう問題

### DIFF
--- a/src/app/(menu)/(public)/[username]/posts/_components/PostPage.tsx
+++ b/src/app/(menu)/(public)/[username]/posts/_components/PostPage.tsx
@@ -2,7 +2,7 @@
 
 import PrimaryColumn from '@/app/(menu)/_components/main/PrimaryColumn';
 import { UserPost } from '@cuculus/cuculus-api';
-import { usePostImmutable } from '@/swr/client/post';
+import { usePost } from '@/swr/client/post';
 import Post from '@/app/(menu)/_components/timeline/layouts/Post';
 
 type Props = {
@@ -12,7 +12,7 @@ type Props = {
 
 // FIXME 仮作成。一旦タイムラインのコンポーネントと同じものを使用する
 export function PostPage({ postId, fallbackData }: Props) {
-  const { data } = usePostImmutable(postId, fallbackData);
+  const { data } = usePost(postId, fallbackData);
 
   if (!data) {
     // FIXME 読み込み中

--- a/src/app/(menu)/_components/timeline/TimelinePost.tsx
+++ b/src/app/(menu)/_components/timeline/TimelinePost.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { usePostImmutable } from '@/swr/client/post';
+import { usePost } from '@/swr/client/post';
 import ViewTrigger from '@/app/(menu)/_components/timeline/ViewportTrigger';
 import Post from '@/app/(menu)/_components/timeline/layouts/Post';
 import { UserPost } from '@cuculus/cuculus-api';
@@ -21,7 +21,7 @@ function TimelinePost({
 }) {
   // FIXME 個別取得APIが出来たらmutateで更新するようにする
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data, mutate } = usePostImmutable(postId, fallbackData);
+  const { data, mutate } = usePost(postId, fallbackData);
 
   return data ? (
     <ViewTrigger

--- a/src/swr/client/post.ts
+++ b/src/swr/client/post.ts
@@ -1,5 +1,4 @@
 import useSWR from 'swr';
-import useSWRImmutable from 'swr/immutable';
 import useSWRMutation from 'swr/mutation';
 import { postsApi } from '@/libs/cuculus-client';
 import { CreatePostRequest, UserPost } from '@cuculus/cuculus-api';
@@ -61,19 +60,6 @@ const update = async (
 };
 
 /**
- * ポスト取得
- * 自動検証されないので、一覧ページで使うのが望ましい
- * @param postId
- * @param initialData
- */
-export const usePostImmutable = (postId: string, initialData?: UserPost) => {
-  const { data: authId } = useAuth();
-  return useSWRImmutable<UserPost>(getKey(postId, authId), fetcher, {
-    fallbackData: initialData,
-  });
-};
-
-/**
  * 投稿に対するアクション
  * ※非ログイン状態だと使えません。
  * @param postId
@@ -95,10 +81,13 @@ export const usePostMutation = (postId: string) => {
  * ポスト取得
  * 自動再検証されるので、詳細ページで使うのが望ましい
  * @param postId
+ * @param initialData
  */
-export const usePost = (postId: string) => {
+export const usePost = (postId: string, initialData?: UserPost) => {
   const { data: authId } = useAuth();
-  return useSWR<UserPost>(getKey(postId, authId), fetcher);
+  return useSWR<UserPost>(getKey(postId, authId), fetcher, {
+    fallbackData: initialData,
+  });
 };
 
 type SendKey = {

--- a/src/swr/client/user.ts
+++ b/src/swr/client/user.ts
@@ -32,7 +32,6 @@ export const useUser = (username: string, fallbackData?: UserWithFollows) => {
     fetcher,
     {
       fallbackData,
-      revalidateIfStale: false,
     },
   );
 };


### PR DESCRIPTION
## Issue

- Github Issue: #117 

## 変更内容
`revalidateIfStale`が`true`になっていると`fallbackData`で初期値を入れた際に再フェッチが走らない為、
該当箇所で`revalidateIfStale`を`false`または`useSWRImmutable`を使用しないようにしました。

## 確認方法
1. 自分のユーザー情報と投稿ページアクセスします。(URLは直接踏むこと)
https://develop.cuculus.jp/takecchi
https://develop.cuculus.jp/takecchi/posts/45210834500067328

2. アイコンを変更します。
3. 再度、自分のユーザー情報と投稿ページアクセスした際に一瞬古いアイコンが表示され、アイコンが変化すればオッケーです。(URLは直接踏むこと)
https://develop.cuculus.jp/takecchi
https://develop.cuculus.jp/takecchi/posts/45210834500067328


## Screenshot (任意)
