### PR TITLE
preconnectでバックエンドへの接続速度を上げる

### DIFF
--- a/src/pages/_meta.tsx
+++ b/src/pages/_meta.tsx
@@ -44,6 +44,7 @@ export default function MetaHead({ metadata }: PageProps) {
       ))}
       <link rel="shortcut icon" href="/icon.png" type="image/png" />
       <link rel="apple-touch-icon" href="/apple-icon.png" type="image/png" />
+      <link rel="preconnect" href={process.env.NEXT_PUBLIC_CUCULUS_API_URL} />
     </Head>
   );
 }


### PR DESCRIPTION
## Issue

- Github Issue: #239 

## 変更内容
APIサーバのドメインをpreconnectとして設定することで接続速度を上げる。

@coderabbitai: ignore
