### PR TITLE
ActivityPub対応準備

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -9,6 +9,16 @@ const handle = app.getRequestHandler();
 // Next.js を localhost:3000 で起動
 app.prepare().then(() => {
   const server = express();
+
+  // .well-known/*へのリクエストをプロキシする
+  server.use(
+    '/.well-known/*',
+    createProxyMiddleware({
+      target: 'http://localhost:8080',
+      changeOrigin: true,
+    }),
+  );
+
   server.all('*', (req, res) => {
     return handle(req, res);
   });

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,5 +1,13 @@
 import { SSTConfig } from 'sst';
 import { NextjsSite } from 'sst/constructs';
+import { HttpOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import {
+  AllowedMethods,
+  CachePolicy,
+  OriginProtocolPolicy,
+  OriginRequestPolicy,
+  ViewerProtocolPolicy,
+} from 'aws-cdk-lib/aws-cloudfront';
 
 export default {
   config(_input) {
@@ -28,6 +36,21 @@ export default {
         warm: 100,
         memorySize: '2048 MB',
         logging: 'combined',
+        cdk: {
+          distribution: {
+            additionalBehaviors: {
+              '.well-known/*': {
+                origin: new HttpOrigin(`api.${domain}`, {
+                  protocolPolicy: OriginProtocolPolicy.MATCH_VIEWER,
+                }),
+                viewerProtocolPolicy: ViewerProtocolPolicy.ALLOW_ALL,
+                allowedMethods: AllowedMethods.ALLOW_ALL,
+                cachePolicy: CachePolicy.CACHING_DISABLED,
+                originRequestPolicy: OriginRequestPolicy.ALL_VIEWER,
+              },
+            },
+          },
+        },
       });
 
       stack.addOutputs({


### PR DESCRIPTION
## Issue

- Github Issue: #295 

## 変更内容
- `.well-known/*`宛のリクエストをAPIに転送するように
  - AWS環境ではCloudFrontの設定
  - ローカル、その他環境ではNext.jsのサーバーサイド処理

## 確認方法
https://develop.cuculus.jp/.well-known/webfinger
にアクセスを行いAPIのレスポンスが返却されていればOK

## Screenshot (任意)

## ChatGPTによるレビュー (任意)
@coderabbitai: ignore
