### PR TITLE
ActivityPub対応準備

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -28,6 +28,15 @@ app.prepare().then(() => {
     }),
   );
 
+  // nodeinfo/*へのリクエストをプロキシする
+  server.use(
+    '/nodeinfo/*',
+    createProxyMiddleware({
+      target: 'http://localhost:8080',
+      changeOrigin: true,
+    }),
+  );
+
   server.all('*', (req, res) => {
     return handle(req, res);
   });

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -51,6 +51,7 @@ export default {
             additionalBehaviors: {
               '.well-known/*': apiBehavior,
               'users/*': apiBehavior,
+              'nodeinfo/*': apiBehavior,
             },
           },
         },


### PR DESCRIPTION
## 変更内容
- `nodeinfo/*`宛のリクエストをAPIに転送するように
  - AWS環境ではCloudFrontの設定
  - ローカルではproxy

@coderabbitai: ignore
