### PR TITLE
ActivityPub用エンドポイントのパスを/ap/~に統一

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -19,27 +19,9 @@ app.prepare().then(() => {
     }),
   );
 
-  // users/*へのリクエストをプロキシする
+  // ap/*へのリクエストをプロキシする
   server.use(
-    '/users/*',
-    createProxyMiddleware({
-      target: 'http://localhost:8080',
-      changeOrigin: true,
-    }),
-  );
-
-  // nodeinfo/*へのリクエストをプロキシする
-  server.use(
-    '/nodeinfo/*',
-    createProxyMiddleware({
-      target: 'http://localhost:8080',
-      changeOrigin: true,
-    }),
-  );
-
-  // inboxへのリクエストをプロキシする
-  server.use(
-    '/inbox',
+    '/ap/*',
     createProxyMiddleware({
       target: 'http://localhost:8080',
       changeOrigin: true,

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -50,9 +50,7 @@ export default {
           distribution: {
             additionalBehaviors: {
               '.well-known/*': apiBehavior,
-              'users/*': apiBehavior,
-              'nodeinfo/*': apiBehavior,
-              inbox: apiBehavior,
+              'ap/*': apiBehavior,
             },
           },
         },


### PR DESCRIPTION
## 変更内容
- ActivityPub用のエンドポイントのパスを`/ap/*`に変更しました。

@coderabbitai: ignore
