### PR TITLE
フォローボタン改修（フォロリク、キャンセル）

### DIFF
--- a/src/app/(menu)/(public)/[username]/_components/elements/FollowButton.tsx
+++ b/src/app/(menu)/(public)/[username]/_components/elements/FollowButton.tsx
@@ -12,12 +12,6 @@ const RemoveButton = styled(CapsuleButton)`
     border-color: ${({ theme }) => theme.palette.error.main};
   }
 `;
-const CancelButton = styled(CapsuleButton)`
-  &:hover {
-    color: ${({ theme }) => theme.palette.error.main};
-    border-color: ${({ theme }) => theme.palette.error.main};
-  }
-`;
 
 /**
  * フォローボタン
@@ -37,7 +31,7 @@ export default function FollowButton({ userId }: { userId: number }) {
   // Relationshipが承認待ちの場合はキャンセルボタンを表示
   if (relationship.followRequested) {
     return (
-      <CancelButton
+      <RemoveButton
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         aria-label={'キャンセル'}
@@ -47,7 +41,7 @@ export default function FollowButton({ userId }: { userId: number }) {
         variant={'outlined'}
       >
         {isHover ? 'キャンセル' : '承認待ち'}
-      </CancelButton>
+      </RemoveButton>
     );
   }
 

--- a/src/app/(menu)/(public)/[username]/_components/elements/FollowButton.tsx
+++ b/src/app/(menu)/(public)/[username]/_components/elements/FollowButton.tsx
@@ -12,6 +12,12 @@ const RemoveButton = styled(CapsuleButton)`
     border-color: ${({ theme }) => theme.palette.error.main};
   }
 `;
+const CancelButton = styled(CapsuleButton)`
+  &:hover {
+    color: ${({ theme }) => theme.palette.error.main};
+    border-color: ${({ theme }) => theme.palette.error.main};
+  }
+`;
 
 /**
  * フォローボタン
@@ -26,6 +32,23 @@ export default function FollowButton({ userId }: { userId: number }) {
   // ロード中または非ログイン時は何も表示しない
   if (!relationship) {
     return <></>;
+  }
+
+  // Relationshipが承認待ちの場合はキャンセルボタンを表示
+  if (relationship.followRequested) {
+    return (
+      <CancelButton
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        aria-label={'キャンセル'}
+        onClick={() => {
+          void updateFollow(false);
+        }}
+        variant={'outlined'}
+      >
+        {isHover ? 'キャンセル' : '承認待ち'}
+      </CancelButton>
+    );
   }
 
   // 非フォローの場合はフォローボタンを表示


### PR DESCRIPTION
## Issue

- Github Issue: #365 
## 変更内容
(変更した内容を記載してください)

## 確認方法
http://localhost:3000/takecchi　のフォローボタンを押下

## Screenshot (任意)

## ChatGPTによるレビュー (任意)
最下部の一文`@coderabbitai`を削除することで有効となります。
指摘内容に対してコメントすることで対話が可能です。

※まだ精度としては甘いです。あくまで見直すキッカケくらいにお考えください。

@coderabbitai: ignore
