### PR TITLE
WIPフォロー・フォロワー一覧

### DIFF
--- a/src/app/(menu)/(public)/[username]/_components/layouts/FFProfileCard.tsx
+++ b/src/app/(menu)/(public)/[username]/_components/layouts/FFProfileCard.tsx
@@ -4,6 +4,12 @@ import UserIcon from '@/app/(menu)/(public)/[username]/_components/elements/User
 import { UserWithFollows } from '@cuculus/cuculus-api';
 import { Box, Typography, styled } from '@mui/material';
 
+const UnselectableCard = styled('div')`
+  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[100]};
+  background-color: ${({ theme }) => theme.palette.background.paper};
+  color: rgba(0, 0, 0, 0.87);
+`;
+
 const Flex = styled(Box)`
   display: flex;
   flex-wrap: nowrap;
@@ -22,6 +28,10 @@ const HFlexS = styled(Flex)`
   justify-content: space-between;
 `;
 
+const FillFlex = styled(Box)`
+  flex-grow: 1;
+`;
+
 const DisplayName = styled(Typography)`
   word-wrap: break-word;
   font-weight: bold;
@@ -35,14 +45,27 @@ const UserName = styled(Typography)`
 
 const Avater = styled(UserIcon)`
   aspect-ratio: 1;
-  height: 60px;
-  width: 60px;
+  height: 64px;
+  width: 64px;
   margin: auto 10px;
+  margin-top: 0;
+
+  ${({ theme }) => theme.breakpoints.down('desktop')} {
+    margin: auto 10px;
+    margin-top: 0;
+    height: 64px;
+    width: 64px;
+  }
 `;
 
 const Bio = styled(Typography)`
   white-space: pre-wrap;
   margin-bottom: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 `;
 
 type FFProfileCardProps = {
@@ -63,7 +86,7 @@ export default function FFProfileCard({
 }: FFProfileCardProps) {
   const isMe = id === authId;
   return (
-    <div>
+    <UnselectableCard>
       <HFlex>
         <Avater src={profileImageUrl} alt={'プロフィール画像'} />
         <VFlex style={{ margin: '12px 0' }}>
@@ -75,12 +98,14 @@ export default function FFProfileCard({
             {/* {authId && !isMe && <FollowButton userId={id} />} */}
             <FollowButton userId={1} />
           </HFlexS>
-          <Bio>
-            {bio}
-            1234567890aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaあああああああああああああああああああああああああああああ
-          </Bio>
+          <FillFlex>
+            <Bio>
+              {bio}
+              あああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああ
+            </Bio>
+          </FillFlex>
         </VFlex>
       </HFlex>
-    </div>
+    </UnselectableCard>
   );
 }

--- a/src/app/(menu)/(public)/[username]/_components/layouts/FFProfileCard.tsx
+++ b/src/app/(menu)/(public)/[username]/_components/layouts/FFProfileCard.tsx
@@ -1,0 +1,86 @@
+'use client';
+import FollowButton from '@/app/(menu)/(public)/[username]/_components/elements/FollowButton';
+import UserIcon from '@/app/(menu)/(public)/[username]/_components/elements/UserIcon';
+import { UserWithFollows } from '@cuculus/cuculus-api';
+import { Box, Typography, styled } from '@mui/material';
+
+const Flex = styled(Box)`
+  display: flex;
+  flex-wrap: nowrap;
+`;
+
+const VFlex = styled(Flex)`
+  flex-direction: column;
+`;
+
+const HFlex = styled(Flex)`
+  flex-direction: row;
+`;
+
+const HFlexS = styled(Flex)`
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const DisplayName = styled(Typography)`
+  word-wrap: break-word;
+  font-weight: bold;
+  font-size: 20px;
+`;
+
+const UserName = styled(Typography)`
+  color: #8899a6;
+  font-size: 15px;
+`;
+
+const Avater = styled(UserIcon)`
+  aspect-ratio: 1;
+  height: 60px;
+  width: 60px;
+  margin: auto 10px;
+`;
+
+const Bio = styled(Typography)`
+  white-space: pre-wrap;
+  margin-bottom: 12px;
+`;
+
+type FFProfileCardProps = {
+  displayName: string;
+  userName: string;
+  profileAvatarImageUrl: string;
+  bio: string;
+  authId: number | undefined;
+} & UserWithFollows;
+
+export default function FFProfileCard({
+  displayname,
+  username,
+  profileImageUrl,
+  bio,
+  authId,
+  id,
+}: FFProfileCardProps) {
+  const isMe = id === authId;
+  return (
+    <div>
+      <HFlex>
+        <Avater src={profileImageUrl} alt={'プロフィール画像'} />
+        <VFlex style={{ margin: '12px 0' }}>
+          <HFlexS>
+            <VFlex>
+              <DisplayName>{displayname}ユーザー表示名</DisplayName>
+              <UserName>@{username}usernoid</UserName>
+            </VFlex>
+            {/* {authId && !isMe && <FollowButton userId={id} />} */}
+            <FollowButton userId={1} />
+          </HFlexS>
+          <Bio>
+            {bio}
+            1234567890aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaあああああああああああああああああああああああああああああ
+          </Bio>
+        </VFlex>
+      </HFlex>
+    </div>
+  );
+}

--- a/src/app/(menu)/(public)/[username]/followers/page.tsx
+++ b/src/app/(menu)/(public)/[username]/followers/page.tsx
@@ -6,6 +6,22 @@ export default function page({}: { params: { userName: string } }) {
   return (
     <PrimaryColumn hideHeader={true}>
       <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
+      <FFProfileCard />
       {/* <ComingSoon /> */}
     </PrimaryColumn>
   );

--- a/src/app/(menu)/(public)/[username]/followers/page.tsx
+++ b/src/app/(menu)/(public)/[username]/followers/page.tsx
@@ -1,10 +1,12 @@
+import FFProfileCard from '@/app/(menu)/(public)/[username]/_components/layouts/FFProfileCard';
 import ComingSoon from '@/app/(menu)/_components/main/ComingSoon';
 import PrimaryColumn from '@/app/(menu)/_components/main/PrimaryColumn';
 
 export default function page({}: { params: { userName: string } }) {
   return (
     <PrimaryColumn hideHeader={true}>
-      <ComingSoon />
+      <FFProfileCard />
+      {/* <ComingSoon /> */}
     </PrimaryColumn>
   );
 }


### PR DESCRIPTION
## Issue

- Github Issue: #351 

## 変更内容
フォロー・フォロワー一覧向けのユーザーカードコンポーネントを作成

## 確認方法
フォロー・フォロワー一覧を開く

## Screenshot (任意)

## ChatGPTによるレビュー (任意)
最下部の一文`@coderabbitai`を削除することで有効となります。
指摘内容に対してコメントすることで対話が可能です。

※まだ精度としては甘いです。あくまで見直すキッカケくらいにお考えください。