### PR TITLE
タイムライン取得処理の修正

### DIFF
--- a/src/libs/swr/timeline/types.ts
+++ b/src/libs/swr/timeline/types.ts
@@ -75,6 +75,8 @@ export interface TimelineDataCacheValue<
   _keys?: SWRKey[];
   // mutate trigger
   _trigger?: 'older' | 'latest' | 'gap';
+  // latest
+  _latest?: Data;
 }
 
 export interface ResultDataCacheValue<Data = never, Error = never>


### PR DESCRIPTION
## Issue

- Github Issue: #402

## 変更内容
- タイムライン取得処理を修正しました。

## 確認方法
1. キューが溜まってない状態(◯件のポストを表示が出ていない状態)でブラウザのタブを変更
2. 最新ポストを20件以上貯めた状態でタブに戻る
3. 「20件のポストを表示」が出ているのでタップ
4. 「更に読み込む」が表示されている
5. 「更に読み込む」をタップすると間の投稿が取得できること

## Screenshot (任意)

@coderabbitai: ignore
